### PR TITLE
Fix LCD float garbage on in-session screen

### DIFF
--- a/Core/Src/Tasks/LCD/LumexLCD.cpp
+++ b/Core/Src/Tasks/LCD/LumexLCD.cpp
@@ -245,7 +245,13 @@ bool LumexLCD::DisplayString(uint8_t row, uint8_t column, const char* string, si
 		}
 
 		column++;
-		column %= 16;
+
+		// Clamp instead of wrapping: drop any chars past the last column so an
+		// overflow fails visibly in one cell rather than corrupting another row.
+		if (column >= 16)
+		{
+			break;
+		}
 	}
 
 	return true;

--- a/Core/Src/Tasks/SessionController/FiniteStateMachine.cpp
+++ b/Core/Src/Tasks/SessionController/FiniteStateMachine.cpp
@@ -506,7 +506,9 @@ void FSM::DisplayTorque(float torque)
     float value = std::round(torque * 100.0) / 100.0;
     snprintf(buf, sizeof(buf), "%5.2f", value);
 
-    AddToLumexLCDMessageQueue(WRITE_TO_DISPLAY, 0, 12, buf, sizeof(buf) - 1);
+    // %5.2f is 5 chars wide; start at col 11 (blank separator) so it fits cols 11-15
+    // instead of overflowing past col 15 and wrapping onto col 0 (overwriting 'n').
+    AddToLumexLCDMessageQueue(WRITE_TO_DISPLAY, 0, 11, buf, sizeof(buf) - 1);
 }
 
 void FSM::DisplayPower(float power)

--- a/cmake/gcc-arm-none-eabi.cmake
+++ b/cmake/gcc-arm-none-eabi.cmake
@@ -41,7 +41,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fno-rtti -fno-exceptions -fno-threadsafe-
 
 set(CMAKE_EXE_LINKER_FLAGS "${TARGET_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -T \"${CMAKE_SOURCE_DIR}/STM32H743XX_FLASH.ld\"")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --specs=nano.specs")
+# nano.specs (newlib-nano) omits %f printf support unless _printf_float is forced in.
+# Without this, snprintf("%f", ...) leaves the buffer uninitialized -> LCD shows garbage.
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --specs=nano.specs -u _printf_float")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=${CMAKE_PROJECT_NAME}.map -Wl,--gc-sections")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--print-memory-usage")
 set(TOOLCHAIN_LINK_LIBRARIES "m")

--- a/cmake/starm-clang.cmake
+++ b/cmake/starm-clang.cmake
@@ -50,7 +50,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fno-rtti -fno-exceptions -fno-threadsafe-
 set(CMAKE_EXE_LINKER_FLAGS "${TARGET_FLAGS}")
 
 if (STARM_TOOLCHAIN_CONFIG STREQUAL "STARM_HYBRID")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --gcc-specs=nano.specs")
+  # nano.specs omits %f printf support unless _printf_float is forced in (see gcc-arm-none-eabi.cmake).
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --gcc-specs=nano.specs -Wl,-u,_printf_float")
   set(TOOLCHAIN_LINK_LIBRARIES "m")
 elseif(STARM_TOOLCHAIN_CONFIG STREQUAL "STARM_NEWLIB")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lcrt0-nosys")


### PR DESCRIPTION
newlib-nano's --specs=nano.specs drops %f printf support unless _printf_float is forced in, so snprintf("%f", ...) left torque/power buffers uninitialized and the LCD rendered garbage. Force-link _printf_float in both toolchains.

Also fix DisplayTorque overflowing its 4-col slot (start at col 11), and make DisplayString clamp at the row edge instead of wrapping onto column 0.