### PR TITLE
MessagePassing: generate message headers from a YAML schema

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             -v "${{ github.workspace }}:/work:z" -w /work \
             --user "$(id -u):$(id -g)" -e HOME=/tmp \
             stm32-dyno-builder:latest \
-            bash -lc "cmake --preset ${{ matrix.config }} && cmake --build --preset ${{ matrix.config }}"
+            bash -lc "python3 tools/message_gen/generate.py && cmake --preset ${{ matrix.config }} && cmake --build --preset ${{ matrix.config }}"
 
       - name: Upload firmware
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  generated-headers:
+    name: generated headers in sync with schema
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install codegen dependencies
+        run: pip install -r tools/message_gen/requirements.txt
+
+      - name: Verify committed headers match their schema
+        run: python tools/message_gen/check.py
+
   build:
     name: build (${{ matrix.config }})
     runs-on: ubuntu-latest

--- a/Core/Inc/MessagePassing/messages_private.h
+++ b/Core/Inc/MessagePassing/messages_private.h
@@ -1,3 +1,5 @@
+// AUTO-GENERATED from tools/message_gen/schema/messages_private.yaml by generate.py -- DO NOT EDIT.
+// Change that schema and re-run tools/message_gen/generate.py (CI verifies they match).
 #ifndef INC_MAIN_BOARD_MESSAGEPASSING_MESSAGES_PRIVATE_H_
 #define INC_MAIN_BOARD_MESSAGEPASSING_MESSAGES_PRIVATE_H_
 
@@ -5,9 +7,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stddef.h>
-
 #include "cmsis_os2.h"
-
 #include "Config/config.h"
 #include "messages_public.h"
 
@@ -18,79 +18,76 @@ extern "C" {
 // Opcodes for controlling the Lumex LCD display from the session controller
 typedef enum : uint32_t
 {
-	CLEAR_DISPLAY = 0,      // Clear the entire display
-	WRITE_TO_DISPLAY = 1   // Write a string to a specific location on the display
+    CLEAR_DISPLAY = 0,   // Clear the entire display
+    WRITE_TO_DISPLAY = 1   // Write a string to a specific location on the display
 } session_controller_to_lumex_lcd_opcode;
 
 _Static_assert(sizeof(session_controller_to_lumex_lcd_opcode) == 4, "Size of session_controller_to_lumex_lcd_opcode must be 4 bytes");
 
 // Message sent from the session controller to the Lumex LCD
 typedef struct {
-	session_controller_to_lumex_lcd_opcode op;  // Operation to perform on the display
-    uint32_t row;                                // Row number on the LCD
-    uint32_t column;                             // Column number on the LCD
-	size_t size;
-	char display_string[SESSION_CONTROLLER_TO_LUMEX_LCD_MSG_STRING_SIZE];                       // String to write (if WRITE_TO_DISPLAY)
+    session_controller_to_lumex_lcd_opcode op;   // Operation to perform on the display
+    uint32_t row;   // Row number on the LCD
+    uint32_t column;   // Column number on the LCD
+    size_t size;
+    char display_string[SESSION_CONTROLLER_TO_LUMEX_LCD_MSG_STRING_SIZE];   // String to write (if WRITE_TO_DISPLAY)
 } session_controller_to_lumex_lcd;
 
-_Static_assert(sizeof(session_controller_to_lumex_lcd) >= 
-               offsetof(session_controller_to_lumex_lcd, display_string) + sizeof(((session_controller_to_lumex_lcd *)0)->display_string),
-               "Size of session_controller_to_lumex_lcd must be correct");
-
+_Static_assert(sizeof(session_controller_to_lumex_lcd) >= offsetof(session_controller_to_lumex_lcd, display_string) + sizeof(((session_controller_to_lumex_lcd *)0)->display_string), "Size of session_controller_to_lumex_lcd must be correct");
 
 // Opcodes for controlling the BPM (Pulse Width Modulation) module from the session controller
 typedef enum : uint32_t
 {
-	READ_FROM_PID = 0,		// read from PID Controller
-	START_PWM,         		// Start PWM output
-	STOP_PWM              // Stop PWM output
+    READ_FROM_PID = 0,   // read from PID Controller
+    START_PWM,   // Start PWM output
+    STOP_PWM   // Stop PWM output
 } session_controller_to_bpm_opcode;
 
 _Static_assert(sizeof(session_controller_to_bpm_opcode) == 4, "Size of session_controller_to_bpm_opcode must be 4 bytes");
 
 // Message sent from the session controller to the BPM module
 typedef struct {
-	session_controller_to_bpm_opcode op;  // Operation to perform on the BPM
-	float new_duty_cycle_percent;              		// New duty cycle percentage from 0 - 1
+    session_controller_to_bpm_opcode op;   // Operation to perform on the BPM
+    float new_duty_cycle_percent;   // New duty cycle percentage from 0 - 1
 } session_controller_to_bpm;
 
 _Static_assert(sizeof(session_controller_to_bpm) == 4 + 4, "Size of session_controller_to_bpm must be 8 bytes");
 
-
 // Message sent from the session controller to the PID controller
-typedef struct
-{
-	bool enable_status;   // Enable or disable the PID controller
-	float desired_angular_velocity;    // Desired motor RPM setpoint
+typedef struct {
+    bool enable_status;   // Enable or disable the PID controller
+    float desired_angular_velocity;   // Desired motor RPM setpoint
 } session_controller_to_pid_controller;
 
 _Static_assert(sizeof(session_controller_to_pid_controller) == 4 + 4, "Size of session_controller_to_pid_controller must be 8 bytes");
 
-
 // ---- USB host command routing (USB task <-> owning task) ------------------
 // Largest command body the USB task will forward to a task (after the
 // usb_cmd_header_t). Keep small; settings are a few bytes.
+
 #define USB_TASK_CMD_BODY_MAX 16
 
 // A host setting routed from the USB task straight to the owning task's command
 // queue. opcode/body are the task-local command; msg_id is the host correlation id
 // (0 => firmware-internal, no host ack). The target task parses body by opcode.
+
 typedef struct {
-	uint16_t opcode;
-	uint16_t msg_id;
-	uint8_t  body[USB_TASK_CMD_BODY_MAX];
-	uint8_t  body_len;
+    uint16_t opcode;
+    uint16_t msg_id;
+    uint8_t body[USB_TASK_CMD_BODY_MAX];
+    uint8_t body_len;
 } usb_task_command;
 
 // A completion the owning task posts back (shared queue) once it has applied a
 // command. The USB task drains these and frames a USB_MSG_RESPONSE to the host,
 // echoing msg_id with the real status — the far end of the full-path ack. msg_id 0
 // completions are dropped (internal commands the host never asked about).
+
 typedef struct {
-	task_offset_t task_offset;   // which module completed the command
-	uint16_t opcode;
-	uint16_t msg_id;
-	uint32_t status;             // usb_response_status_t
+    task_offset_t task_offset;   // which module completed the command
+    uint16_t opcode;
+    uint16_t msg_id;
+    uint32_t status;   // usb_response_status_t
 } usb_task_completion;
 
 #ifdef __cplusplus

--- a/Core/Inc/MessagePassing/messages_public.h
+++ b/Core/Inc/MessagePassing/messages_public.h
@@ -1,3 +1,5 @@
+// AUTO-GENERATED from tools/message_gen/schema/messages_public.yaml by generate.py -- DO NOT EDIT.
+// Change that schema and re-run tools/message_gen/generate.py (CI verifies they match).
 #ifndef INC_MAIN_BOARD_MESSAGEPASSING_MESSAGES_PUBLIC_H_
 #define INC_MAIN_BOARD_MESSAGEPASSING_MESSAGES_PUBLIC_H_
 
@@ -11,10 +13,14 @@
 //   bits 14..0  : task-local error number
 // An error code is formed by OR-ing the task offset with the error number, so the
 // task id no longer needs to be sent as a separate field.
-#define TASK_OFFSET_SHIFT    16u
-#define WARNING_FLAG         (1u << 15)
-#define TASK_ERROR_NUM_MASK  (WARNING_FLAG - 1u)              // bits 0..14
-#define TASK_OFFSET_MASK     (0xFFFFu << TASK_OFFSET_SHIFT)   // bits 16..31
+
+#define TASK_OFFSET_SHIFT 16u
+
+#define WARNING_FLAG (1u << 15)
+
+#define TASK_ERROR_NUM_MASK (WARNING_FLAG - 1u)              // bits 0..14
+
+#define TASK_OFFSET_MASK (0xFFFFu << TASK_OFFSET_SHIFT)              // bits 16..31
 
 #ifdef __cplusplus
 extern "C" {
@@ -23,34 +29,30 @@ extern "C" {
 // ****************************************************
 // ERRORS AND WARNINGS
 // ****************************************************
+
 // Unique per-task offset occupying the high bits of an error code. OR-ed with a
 // task-local error number to form the error_code sent over USB.
 typedef enum : uint32_t
 {
-	TASK_OFFSET_NO_TASK              = 0xFFFFu << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_TASK_MONITOR         = 0u  << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_SESSION_CONTROLLER   = 1u  << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_USB_CONTROLLER       = 2u  << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_SD_CONTROLLER        = 3u  << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_OPTICAL_ENCODER      = 4u  << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_FORCE_SENSOR_ADC     = 5u  << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_FORCE_SENSOR_ADS1115 = 6u  << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_BPM_CONTROLLER       = 7u  << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_PID_CONTROLLER       = 8u  << TASK_OFFSET_SHIFT,
-	TASK_OFFSET_LUMEX_LCD            = 9u  << TASK_OFFSET_SHIFT
+    TASK_OFFSET_NO_TASK = 0xFFFFu << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_TASK_MONITOR = 0u  << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_SESSION_CONTROLLER = 1u  << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_USB_CONTROLLER = 2u  << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_SD_CONTROLLER = 3u  << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_OPTICAL_ENCODER = 4u  << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_FORCE_SENSOR_ADC = 5u  << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_FORCE_SENSOR_ADS1115 = 6u  << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_BPM_CONTROLLER = 7u  << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_PID_CONTROLLER = 8u  << TASK_OFFSET_SHIFT,
+    TASK_OFFSET_LUMEX_LCD = 9u  << TASK_OFFSET_SHIFT
 } task_offset_t;
 
-typedef struct __attribute__((packed))
-{
+typedef struct __attribute__((packed)) {
     uint32_t timestamp;
     uint32_t error_code;   // task_offset | (warning ? WARNING_FLAG : 0) | error number
 } task_error_data;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(task_error_data) == 4 + 4, "Size of task_error_data must be 8 bytes");
-#else
-static_assert(sizeof(task_error_data) == 4 + 4, "Size of task_error_data must be 8 bytes");
-#endif
 
 static inline task_error_data PopulateTaskErrorDataStruct(uint32_t timestamp, task_offset_t task_offset, uint32_t error_id)
 {
@@ -60,11 +62,7 @@ static inline task_error_data PopulateTaskErrorDataStruct(uint32_t timestamp, ta
     return error_data;
 }
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(task_offset_t) == 4, "Size of task_offset_t must be 4 bytes");
-#else
-static_assert(sizeof(task_offset_t) == 4, "Size of task_offset_t must be 4 bytes");
-#endif
 
 typedef enum : uint32_t
 {
@@ -73,11 +71,7 @@ typedef enum : uint32_t
     ERROR_SESSION_CONTROLLER_INVALID_UART1_MUTEX_POINTER
 } session_controller_task_error_ids;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(session_controller_task_error_ids) == 4, "Size of session_controller_task_error_ids must be 4 bytes");
-#else
-static_assert(sizeof(session_controller_task_error_ids) == 4, "Size of session_controller_task_error_ids must be 4 bytes");
-#endif
 
 typedef enum : uint32_t
 {
@@ -85,55 +79,35 @@ typedef enum : uint32_t
     ERROR_BPM_PWM_STOP_FAILURE
 } bpm_task_error_ids;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(bpm_task_error_ids) == 4, "Size of bpm_task_error_ids must be 4 bytes");
-#else
-static_assert(sizeof(bpm_task_error_ids) == 4, "Size of bpm_task_error_ids must be 4 bytes");
-#endif
 
 typedef enum : uint32_t
 {
     ERROR_LUMEX_LCD_TIMER_START_FAILURE = 0
 } lumex_lcd_task_error_ids;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(lumex_lcd_task_error_ids) == 4, "Size of lumex_lcd_task_error_ids must be 4 bytes");
-#else
-static_assert(sizeof(lumex_lcd_task_error_ids) == 4, "Size of lumex_lcd_task_error_ids must be 4 bytes");
-#endif
 
 typedef enum : uint32_t
 {
     ERROR_TASK_MONITOR_INVALID_THREAD_ID_POINTER = 0
 } task_monitor_task_error_ids;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(task_monitor_task_error_ids) == 4, "Size of task_monitor_task_error_ids must be 4 bytes");
-#else
-static_assert(sizeof(task_monitor_task_error_ids) == 4, "Size of task_monitor_task_error_ids must be 4 bytes");
-#endif
-    
+
 typedef enum : uint32_t
 {
     WARNING_PID_CONTROLLER_MESSAGE_QUEUE_FULL = WARNING_FLAG
 } pid_controller_task_error_ids;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(pid_controller_task_error_ids) == 4, "Size of pid_controller_task_error_ids must be 4 bytes");
-#else
-static_assert(sizeof(pid_controller_task_error_ids) == 4, "Size of pid_controller_task_error_ids must be 4 bytes");
-#endif
 
 typedef enum : uint32_t
 {
     ERROR_FORCE_SENSOR_ADC_START_FAILURE = 0
 } force_sensor_adc_task_error_ids;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(force_sensor_adc_task_error_ids) == 4, "Size of force_sensor_adc_task_error_ids must be 4 bytes");
-#else
-static_assert(sizeof(force_sensor_adc_task_error_ids) == 4, "Size of force_sensor_adc_task_error_ids must be 4 bytes");
-#endif
 
 typedef enum : uint32_t
 {
@@ -142,47 +116,36 @@ typedef enum : uint32_t
     WARNING_FORCE_SENSOR_ADS1115_GET_CONVERSION_FAILURE
 } force_sensor_ads1115_error_ids;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(force_sensor_ads1115_error_ids) == 4, "Size of force_sensor_ads1115_error_ids must be 4 bytes");
-#else
-static_assert(sizeof(force_sensor_ads1115_error_ids) == 4, "Size of force_sensor_ads1115_error_ids must be 4 bytes");
-#endif
-
 
 // ****************************************************
 // USB AND PUBLIC MESSAGES
 // ****************************************************
-typedef enum : uint32_t {
+
+typedef enum : uint32_t
+{
     USB_MSG_INVALID = 0,
 
-    USB_MSG_COMMAND,        // PC → STM32 (do something)
-    USB_MSG_RESPONSE,       // STM32 → PC (reply to command)
-    USB_MSG_EVENT,          // STM32 → PC (async event)
-    USB_MSG_STREAM,         // STM32 → PC (continuous data)
-    USB_MSG_CONFIG,         // PC → STM32 (set parameters)
-    USB_MSG_STATUS,         // STM32 → PC (health / state)
+    USB_MSG_COMMAND,   // PC -> STM32 (do something)
+    USB_MSG_RESPONSE,   // STM32 -> PC (reply to command)
+    USB_MSG_EVENT,   // STM32 -> PC (async event)
+    USB_MSG_STREAM,   // STM32 -> PC (continuous data)
+    USB_MSG_CONFIG,   // PC -> STM32 (set parameters)
+    USB_MSG_STATUS,   // STM32 -> PC (health / state)
 
-    USB_MSG_ERROR,          // STM32 → PC (error report)
-    USB_MSG_WARNING,        // STM32 → PC (warning report)
+    USB_MSG_ERROR,   // STM32 -> PC (error report)
+    USB_MSG_WARNING   // STM32 -> PC (warning report)
 } usb_msg_type_t;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(usb_msg_type_t) == 4, "Size of usb_msg_type_t must be 4 bytes");
-#else
-static_assert(sizeof(usb_msg_type_t) == 4, "Size of usb_msg_type_t must be 4 bytes");
-#endif
 
 typedef struct __attribute__((packed)) {
-    usb_msg_type_t msg_type;     // protocol-level intent
-    task_offset_t  task_offset;  // which module owns payload
-    uint32_t payload_len;  // bytes following header
+    usb_msg_type_t msg_type;   // protocol-level intent
+    task_offset_t task_offset;   // which module owns payload
+    uint32_t payload_len;   // bytes following header
 } usb_msg_header_t;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(usb_msg_header_t) == 12, "Size of usb_msg_header_t must be 12 bytes");
-#else
-static_assert(sizeof(usb_msg_header_t) == 12, "Size of usb_msg_header_t must be 12 bytes");
-#endif
 
 // ---- Host -> device framed command envelope -------------------------------
 // Inbound (PC -> STM32) frames are wrapped so the parser can resync after a ring
@@ -192,14 +155,20 @@ static_assert(sizeof(usb_msg_header_t) == 12, "Size of usb_msg_header_t must be 
 // bytes followed by the payload bytes (the SOF marker and crc field themselves are
 // excluded). Multi-byte fields are little-endian, matching both the STM32 and the
 // x86 host. The same envelope is reused for the host-side parser.
-#define USB_FRAME_SOF        0xA55Au
-#define USB_FRAME_CRC_INIT   0xFFFFu
-#define USB_FRAME_CRC_POLY   0x1021u
+
+#define USB_FRAME_SOF 0xA55Au
+
+#define USB_FRAME_CRC_INIT 0xFFFFu
+
+#define USB_FRAME_CRC_POLY 0x1021u
+
 // Largest inbound payload the firmware accepts; frames claiming more are treated as
 // a spurious SOF and skipped during resync.
-#define USB_RX_MAX_PAYLOAD   128u
+
+#define USB_RX_MAX_PAYLOAD 128u
 
 // Shared CRC so firmware and host compute identical checksums over a frame body.
+
 static inline uint16_t usb_frame_crc16(const uint8_t *data, size_t len)
 {
     uint16_t crc = USB_FRAME_CRC_INIT;
@@ -222,105 +191,83 @@ static inline uint16_t usb_frame_crc16(const uint8_t *data, size_t len)
 // chosen by the host and echoed in the matching RESPONSE so a reply can be
 // correlated to its request. msg_id 0 is reserved for firmware-internal commands
 // that want no host ack; hosts use ids >= 1.
+
 typedef struct __attribute__((packed)) {
     uint16_t opcode;
     uint16_t msg_id;
 } usb_cmd_header_t;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(usb_cmd_header_t) == 4, "Size of usb_cmd_header_t must be 4 bytes");
-#else
-static_assert(sizeof(usb_cmd_header_t) == 4, "Size of usb_cmd_header_t must be 4 bytes");
-#endif
 
 // RESPONSE frame payload (STM32 -> PC): echoes the command's opcode + msg_id and
 // reports a status. Sent with task_offset set to the module that completed it, so
 // the host learns both which message (msg_id) and which module (frame task_offset)
 // acked. For a routed setting this is the full-path ack: it is emitted only after
 // the owning task has actually applied the command, with the real result status.
+
 typedef struct __attribute__((packed)) {
     uint16_t opcode;
     uint16_t msg_id;
     uint32_t status;   // usb_response_status_t
 } usb_response_data_t;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(usb_response_data_t) == 8, "Size of usb_response_data_t must be 8 bytes");
-#else
-static_assert(sizeof(usb_response_data_t) == 8, "Size of usb_response_data_t must be 8 bytes");
-#endif
 
-typedef enum : uint32_t {
+typedef enum : uint32_t
+{
     USB_RSP_OK = 0,
     USB_RSP_UNKNOWN_COMMAND,   // opcode not recognised by the target module
-    USB_RSP_MALFORMED,         // payload too short / body out of range
-    USB_RSP_NOT_SUPPORTED,     // task_offset has no command route
-    USB_RSP_DEVICE_ERROR,      // target applied it but the device write failed (e.g. I2C)
-    USB_RSP_QUEUE_FULL,        // target task's command queue was full
+    USB_RSP_MALFORMED,   // payload too short / body out of range
+    USB_RSP_NOT_SUPPORTED,   // task_offset has no command route
+    USB_RSP_DEVICE_ERROR,   // target applied it but the device write failed (e.g. I2C)
+    USB_RSP_QUEUE_FULL   // target task's command queue was full
 } usb_response_status_t;
 
 // USB-controller-local commands: frames addressed to TASK_OFFSET_USB_CONTROLLER.
-typedef enum : uint16_t {
-    USB_CMD_HELLO = 0,   // host handshake; firmware replies USB_MSG_RESPONSE / USB_RSP_OK
+typedef enum : uint16_t
+{
+    USB_CMD_HELLO = 0   // host handshake; firmware replies USB_MSG_RESPONSE / USB_RSP_OK
 } usb_controller_command_t;
 
 // Force-sensor (ADS1115) commands: frames addressed to TASK_OFFSET_FORCE_SENSOR_ADS1115.
-typedef enum : uint16_t {
-    FORCE_SENSOR_CMD_SET_DATA_RATE = 0,  // body[0] = ADS1115_RATE_* code (0..7)
+typedef enum : uint16_t
+{
+    FORCE_SENSOR_CMD_SET_DATA_RATE = 0   // body[0] = ADS1115_RATE_* code (0..7)
 } force_sensor_command_opcode;
 
-typedef struct
-{
-	uint32_t timestamp;  // Timestamp of the reading 
-	float angular_velocity; // Measured angular velocity
-	uint32_t raw_value;  // In case users want to have custom implementation with it
-	float angular_acceleration; // Measured angular acceleration
+typedef struct {
+    uint32_t timestamp;   // Timestamp of the reading
+    float angular_velocity;   // Measured angular velocity
+    uint32_t raw_value;   // In case users want to have custom implementation with it
+    float angular_acceleration;   // Measured angular acceleration
 } optical_encoder_output_data;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(optical_encoder_output_data) == 4 + 4 + 4 + 4, "Size of optical_encoder_output_data must be 16 bytes");
-#else
-static_assert(sizeof(optical_encoder_output_data) == 4 + 4 + 4 + 4, "Size of optical_encoder_output_data must be 16 bytes");
-#endif
 
 typedef struct {
-	uint32_t timestamp;
-	float force;
-	uint32_t raw_value;
+    uint32_t timestamp;
+    float force;
+    uint32_t raw_value;
 } forcesensor_output_data;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(forcesensor_output_data) == 4 + 4 + 4, "Size of forcesensor_output_data must be 12 bytes");
-#else
-static_assert(sizeof(forcesensor_output_data) == 4 + 4 + 4, "Size of forcesensor_output_data must be 12 bytes");
-#endif
 
-typedef struct
-{
+typedef struct {
     uint32_t timestamp;
     float duty_cycle;
-	uint32_t raw_value; // Really just padding to match the other output data types
+    uint32_t raw_value;   // Really just padding to match the other output data types
 } bpm_output_data;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(bpm_output_data) == 4 + 4 + 4, "Size of bpm_output_data must be 12 bytes");
-#else
-static_assert(sizeof(bpm_output_data) == 4 + 4 + 4, "Size of bpm_output_data must be 12 bytes");
-#endif
 
-typedef struct
-{
-	uint32_t timestamp;
-	task_offset_t task_offset;
-	int task_state;
-	uint32_t free_bytes;
+typedef struct {
+    uint32_t timestamp;
+    task_offset_t task_offset;
+    int task_state;
+    uint32_t free_bytes;
 } task_monitor_output_data;
 
-#ifdef STM32H7xx_H
 _Static_assert(sizeof(task_monitor_output_data) == 4 + 4 + 4 + 4, "Size of task_monitor_output_data must be 16 bytes");
-#else
-static_assert(sizeof(task_monitor_output_data) == 4 + 4 + 4 + 4, "Size of task_monitor_output_data must be 16 bytes");
-#endif
 
 #ifdef __cplusplus
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ ARG ARM_TOOLCHAIN_VERSION=13.3.rel1
 # Update alongside ARM_TOOLCHAIN_VERSION.
 ARG ARM_TOOLCHAIN_SHA256=95c011cee430e64dd6087c75c800f04b9c49832cc1000127a92a97f9c8d83af4
 
-# Host build tools
+# Host build tools. python3 + jinja2 + pyyaml are for tools/message_gen, which
+# regenerates the MessagePassing headers from their YAML schema before each build.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cmake \
         ninja-build \
@@ -22,6 +23,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         wget \
         xz-utils \
         libncurses-dev \
+        python3 \
+        python3-jinja2 \
+        python3-yaml \
     && rm -rf /var/lib/apt/lists/*
 
 # Arm GNU bare-metal toolchain (x86_64 host), pinned and installed to /opt

--- a/Scripts/build-docker.sh
+++ b/Scripts/build-docker.sh
@@ -59,7 +59,7 @@ docker run --rm \
     -v "$MOUNT" -w /work \
     "${USER_FLAGS[@]}" \
     "$IMAGE" \
-    bash -lc "cmake --preset $CONFIG && cmake --build --preset $CONFIG"
+    bash -lc "python3 tools/message_gen/generate.py && cmake --preset $CONFIG && cmake --build --preset $CONFIG"
 
 echo
 echo "Build succeeded! Artifacts in build/$CONFIG/"

--- a/tools/message_gen/.gitignore
+++ b/tools/message_gen/.gitignore
@@ -1,0 +1,5 @@
+# local toolchain + diff sandbox (not part of the build)
+.venv/
+generated/
+__pycache__/
+*.pyc

--- a/tools/message_gen/README.md
+++ b/tools/message_gen/README.md
@@ -1,0 +1,70 @@
+# message_gen
+
+Generates the MessagePassing C headers from a YAML schema, so the wire-protocol
+contract lives in one declarative place instead of being hand-maintained (and
+hand-mirrored on the PC side).
+
+```
+schema/*.yaml  ──(templates/header.h.j2)──►  Core/Inc/MessagePassing/*.h
+```
+
+## Targets
+
+| target             | schema                          | output                                   |
+|--------------------|---------------------------------|------------------------------------------|
+| `messages_public`  | `schema/messages_public.yaml`   | `Core/Inc/MessagePassing/messages_public.h`  |
+| `messages_private` | `schema/messages_private.yaml`  | `Core/Inc/MessagePassing/messages_private.h` |
+
+Both render through the single generic template `templates/header.h.j2`.
+
+## Usage
+
+```sh
+# one-time: deps (Jinja2 + PyYAML)
+python3 -m venv .venv && .venv/bin/pip install jinja2 pyyaml
+
+.venv/bin/python generate.py                       # regenerate every header
+.venv/bin/python generate.py --target messages_public --stdout   # preview one
+```
+
+## Schema reference
+
+`sections:` is an ordered list; each entry has a `kind`:
+
+| kind            | fields                                            | emits                                  |
+|-----------------|---------------------------------------------------|----------------------------------------|
+| `comment`       | `text`                                            | a `//` block                           |
+| `define`        | `name`, `value`, `comment?`                       | `#define`                              |
+| `code`          | `text`                                            | verbatim C (extern "C" guards, helpers)|
+| `enum`          | `name`, `base`, `comment?`, `values[]`            | `typedef enum : base { ... }`          |
+| `struct`        | `name`, `packed?`, `comment?`, `fields[]`         | `typedef struct [packed] { ... }`      |
+| `static_assert` | `expr`, `message`                                 | `_Static_assert(expr, "message");`     |
+
+- enum value: `{ name, value?, comment?, blank_before? }`
+- struct field: `{ type, name, comment?, array? }` (`array: N` -> `type name[N];`)
+- include entry: `"stdint.h"` -> `<stdint.h>`; `{ local: "x.h" }` -> `"x.h"`
+
+`static_assert` is its own ordered section so the size checks land where the original
+header puts them, and so the assert spelling exists in exactly one place (the
+template) instead of being copied per type.
+
+## Verifying / CI drift guard
+
+`verify.py` compares two headers as C token streams (comments, whitespace and a
+trailing comma before `}` are ignored), so an empty diff proves the same C is
+declared regardless of formatting:
+
+```sh
+# regenerate to a temp file and fail if someone hand-edited the committed header
+.venv/bin/python generate.py --target messages_public --out /tmp/gen.h
+.venv/bin/python verify.py Core/Inc/MessagePassing/messages_public.h /tmp/gen.h
+```
+
+## Notes
+
+- Asserts are emitted as `_Static_assert` to match the existing headers. That is a C
+  keyword; mainline g++ rejects it, but these headers are also included by C++ task
+  TUs, so if a host/C++ build ever trips on it, switch the one line in
+  `header.h.j2` to bare `static_assert` (valid in both C23 and C++11+).
+- The PC-side parser can be added as a third target (its own schema/template, same
+  generator) so the firmware header and host parser can never drift.

--- a/tools/message_gen/check.py
+++ b/tools/message_gen/check.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""CI drift guard: every committed header must match what its schema generates.
+
+For each target it renders the header from the schema and compares it against the
+committed file as a C token stream (comments, whitespace and trailing-comma style are
+ignored -- see verify.normalize). Exits non-zero on any drift, names the file, prints
+the offending diff, and says how to fix it. No temp files, no compiler needed.
+
+    python tools/message_gen/check.py
+"""
+
+from __future__ import annotations
+
+import difflib
+import sys
+
+from generate import TARGETS, render
+from verify import normalize
+
+
+def main() -> int:
+    failed: list[str] = []
+    for name in sorted(TARGETS):
+        schema_path, template_name, out_path = TARGETS[name]
+        if not out_path.exists():
+            print(f"FAIL {name}: {out_path} does not exist")
+            failed.append(name)
+            continue
+
+        committed = normalize(out_path.read_text())
+        generated = normalize(render(schema_path, template_name))
+        if committed == generated:
+            print(f"OK   {name}: {out_path} matches {schema_path.name}")
+            continue
+
+        failed.append(name)
+        print(f"FAIL {name}: {out_path} is out of sync with {schema_path.name}")
+        diff = difflib.unified_diff(
+            committed, generated,
+            f"committed:{out_path.name}", f"from-schema:{schema_path.name}",
+            lineterm="",
+        )
+        print("\n".join(diff))
+
+    if failed:
+        print(
+            f"\n{len(failed)} header(s) out of sync: {', '.join(failed)}\n"
+            "Regenerate and commit:  python tools/message_gen/generate.py",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nAll {len(TARGETS)} generated headers are in sync with their schemas.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/message_gen/generate.py
+++ b/tools/message_gen/generate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Generate C headers for the USB / message-passing wire protocol from a YAML schema.
+
+Single source of truth: tools/message_gen/schema/*.yaml. Edit the schema, run this,
+and the C header is regenerated. Later the same schema can also emit the host-side
+parser from a second template, so the two can never drift.
+
+Usage:
+    generate.py                      # regenerate every target into the tree
+    generate.py --target X           # regenerate just target X
+    generate.py --target X --stdout  # print X to stdout (don't touch the tree)
+    generate.py --target X --out f   # write X somewhere else (used by the diff check)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+MSG_DIR = REPO / "Core" / "Inc" / "MessagePassing"
+
+# target -> (schema file, template file, default output). One generic template drives
+# every header; add the C++ host parser here later as its own (schema, template, out).
+TARGETS = {
+    "messages_public": (
+        HERE / "schema" / "messages_public.yaml",
+        "header.h.j2",
+        MSG_DIR / "messages_public.h",
+    ),
+    "messages_private": (
+        HERE / "schema" / "messages_private.yaml",
+        "header.h.j2",
+        MSG_DIR / "messages_private.h",
+    ),
+}
+
+
+def render(schema_path: Path, template_name: str) -> str:
+    schema = yaml.safe_load(schema_path.read_text())
+    env = Environment(
+        loader=FileSystemLoader(HERE / "templates"),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+    )
+    return env.get_template(template_name).render(schema_name=schema_path.name, **schema)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--target", choices=sorted(TARGETS),
+                    help="only this target (default: all)")
+    ap.add_argument("--stdout", action="store_true", help="print instead of writing")
+    ap.add_argument("--out", type=Path, help="override output path (single target only)")
+    args = ap.parse_args(argv)
+
+    targets = [args.target] if args.target else sorted(TARGETS)
+    if (args.stdout or args.out) and len(targets) != 1:
+        ap.error("--stdout/--out require a single --target")
+
+    for name in targets:
+        schema_path, template_name, default_out = TARGETS[name]
+        text = render(schema_path, template_name)
+        if args.stdout:
+            sys.stdout.write(text)
+            continue
+        out = args.out or default_out
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text)
+        print(f"wrote {out} ({len(text.splitlines())} lines)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/message_gen/requirements.txt
+++ b/tools/message_gen/requirements.txt
@@ -1,0 +1,2 @@
+jinja2
+pyyaml

--- a/tools/message_gen/schema/messages_private.yaml
+++ b/tools/message_gen/schema/messages_private.yaml
@@ -1,0 +1,123 @@
+# Source-of-truth schema for Core/Inc/MessagePassing/messages_private.h
+#
+# Firmware-internal inter-task queue payloads (not part of the USB wire contract).
+# Section kinds and field options are documented in schema/messages_public.yaml and
+# templates/header.h.j2.
+
+guard: INC_MAIN_BOARD_MESSAGEPASSING_MESSAGES_PRIVATE_H_
+includes:
+  - stdint.h
+  - stdbool.h
+  - stdlib.h
+  - stddef.h
+  - { local: cmsis_os2.h }
+  - { local: Config/config.h }
+  - { local: messages_public.h }
+
+sections:
+  - kind: code
+    text: |-
+      #ifdef __cplusplus
+      extern "C" {
+      #endif
+
+  - kind: enum
+    name: session_controller_to_lumex_lcd_opcode
+    base: uint32_t
+    comment: |-
+      Opcodes for controlling the Lumex LCD display from the session controller
+    values:
+      - { name: CLEAR_DISPLAY,    value: "0", comment: "Clear the entire display" }
+      - { name: WRITE_TO_DISPLAY, value: "1", comment: "Write a string to a specific location on the display" }
+
+  - { kind: static_assert, expr: "sizeof(session_controller_to_lumex_lcd_opcode) == 4", message: "Size of session_controller_to_lumex_lcd_opcode must be 4 bytes" }
+
+  - kind: struct
+    name: session_controller_to_lumex_lcd
+    comment: |-
+      Message sent from the session controller to the Lumex LCD
+    fields:
+      - { type: session_controller_to_lumex_lcd_opcode, name: op, comment: "Operation to perform on the display" }
+      - { type: uint32_t, name: row,    comment: "Row number on the LCD" }
+      - { type: uint32_t, name: column, comment: "Column number on the LCD" }
+      - { type: size_t,   name: size }
+      - { type: char,     name: display_string, array: SESSION_CONTROLLER_TO_LUMEX_LCD_MSG_STRING_SIZE, comment: "String to write (if WRITE_TO_DISPLAY)" }
+
+  - kind: static_assert
+    expr: "sizeof(session_controller_to_lumex_lcd) >= offsetof(session_controller_to_lumex_lcd, display_string) + sizeof(((session_controller_to_lumex_lcd *)0)->display_string)"
+    message: "Size of session_controller_to_lumex_lcd must be correct"
+
+  - kind: enum
+    name: session_controller_to_bpm_opcode
+    base: uint32_t
+    comment: |-
+      Opcodes for controlling the BPM (Pulse Width Modulation) module from the session controller
+    values:
+      - { name: READ_FROM_PID, value: "0", comment: "read from PID Controller" }
+      - { name: START_PWM, comment: "Start PWM output" }
+      - { name: STOP_PWM,  comment: "Stop PWM output" }
+
+  - { kind: static_assert, expr: "sizeof(session_controller_to_bpm_opcode) == 4", message: "Size of session_controller_to_bpm_opcode must be 4 bytes" }
+
+  - kind: struct
+    name: session_controller_to_bpm
+    comment: |-
+      Message sent from the session controller to the BPM module
+    fields:
+      - { type: session_controller_to_bpm_opcode, name: op, comment: "Operation to perform on the BPM" }
+      - { type: float, name: new_duty_cycle_percent, comment: "New duty cycle percentage from 0 - 1" }
+
+  - { kind: static_assert, expr: "sizeof(session_controller_to_bpm) == 4 + 4", message: "Size of session_controller_to_bpm must be 8 bytes" }
+
+  - kind: struct
+    name: session_controller_to_pid_controller
+    comment: |-
+      Message sent from the session controller to the PID controller
+    fields:
+      - { type: bool,  name: enable_status, comment: "Enable or disable the PID controller" }
+      - { type: float, name: desired_angular_velocity, comment: "Desired motor RPM setpoint" }
+
+  - { kind: static_assert, expr: "sizeof(session_controller_to_pid_controller) == 4 + 4", message: "Size of session_controller_to_pid_controller must be 8 bytes" }
+
+  - kind: comment
+    text: |-
+      ---- USB host command routing (USB task <-> owning task) ------------------
+      Largest command body the USB task will forward to a task (after the
+      usb_cmd_header_t). Keep small; settings are a few bytes.
+
+  - { kind: define, name: USB_TASK_CMD_BODY_MAX, value: "16" }
+
+  - kind: comment
+    text: |-
+      A host setting routed from the USB task straight to the owning task's command
+      queue. opcode/body are the task-local command; msg_id is the host correlation id
+      (0 => firmware-internal, no host ack). The target task parses body by opcode.
+
+  - kind: struct
+    name: usb_task_command
+    fields:
+      - { type: uint16_t, name: opcode }
+      - { type: uint16_t, name: msg_id }
+      - { type: uint8_t,  name: body, array: USB_TASK_CMD_BODY_MAX }
+      - { type: uint8_t,  name: body_len }
+
+  - kind: comment
+    text: |-
+      A completion the owning task posts back (shared queue) once it has applied a
+      command. The USB task drains these and frames a USB_MSG_RESPONSE to the host,
+      echoing msg_id with the real status — the far end of the full-path ack. msg_id 0
+      completions are dropped (internal commands the host never asked about).
+
+  - kind: struct
+    name: usb_task_completion
+    fields:
+      - { type: task_offset_t, name: task_offset, comment: "which module completed the command" }
+      - { type: uint16_t, name: opcode }
+      - { type: uint16_t, name: msg_id }
+      - { type: uint32_t, name: status, comment: "usb_response_status_t" }
+
+  - kind: code
+    text: |-
+      #ifdef __cplusplus
+      }
+      #endif

--- a/tools/message_gen/schema/messages_public.yaml
+++ b/tools/message_gen/schema/messages_public.yaml
@@ -1,0 +1,336 @@
+# Source-of-truth schema for Core/Inc/MessagePassing/messages_public.h
+#
+# This file is the contract shared with the PC software. Edit it, run
+#   tools/message_gen/generate.py
+# and the C header (and, later, the host-side parser) are regenerated.
+#
+# Section kinds (emitted top-to-bottom in the order listed):
+#   comment        a // banner / prose block               -> text
+#   define         a #define                                -> name, value, [comment]
+#   code           verbatim C (extern "C" guards, helpers)  -> text
+#   enum           typedef enum : base { ... }              -> name, base, [comment], values[]
+#   struct         typedef struct [packed] { ... }          -> name, [packed], [comment], fields[]
+#   static_assert  the STM32H7 / host dual-assert block     -> expr, message
+#
+# `static_assert` is its own section so it lands in the original order, and so the
+# 10-line #ifdef STM32H7xx_H / _Static_assert / static_assert boilerplate exists in
+# exactly one place (the template macro) instead of being hand-copied per type.
+
+guard: INC_MAIN_BOARD_MESSAGEPASSING_MESSAGES_PUBLIC_H_
+includes:
+  - stdint.h
+  - stddef.h
+  - assert.h
+
+sections:
+  - kind: comment
+    text: |-
+      A task error/warning is reported as a single 32-bit code:
+        bits 31..16 : task offset (unique per task, see task_offset_t)
+        bit  15     : warning flag (set => warning, clear => error)
+        bits 14..0  : task-local error number
+      An error code is formed by OR-ing the task offset with the error number, so the
+      task id no longer needs to be sent as a separate field.
+
+  - { kind: define, name: TASK_OFFSET_SHIFT,   value: "16u" }
+  - { kind: define, name: WARNING_FLAG,        value: "(1u << 15)" }
+  - { kind: define, name: TASK_ERROR_NUM_MASK, value: "(WARNING_FLAG - 1u)", comment: "bits 0..14" }
+  - { kind: define, name: TASK_OFFSET_MASK,    value: "(0xFFFFu << TASK_OFFSET_SHIFT)", comment: "bits 16..31" }
+
+  - kind: code
+    text: |-
+      #ifdef __cplusplus
+      extern "C" {
+      #endif
+
+  - kind: comment
+    text: |-
+      ****************************************************
+      ERRORS AND WARNINGS
+      ****************************************************
+
+  - kind: enum
+    name: task_offset_t
+    base: uint32_t
+    comment: |-
+      Unique per-task offset occupying the high bits of an error code. OR-ed with a
+      task-local error number to form the error_code sent over USB.
+    values:
+      - { name: TASK_OFFSET_NO_TASK,              value: "0xFFFFu << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_TASK_MONITOR,         value: "0u  << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_SESSION_CONTROLLER,   value: "1u  << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_USB_CONTROLLER,       value: "2u  << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_SD_CONTROLLER,        value: "3u  << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_OPTICAL_ENCODER,      value: "4u  << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_FORCE_SENSOR_ADC,     value: "5u  << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_FORCE_SENSOR_ADS1115, value: "6u  << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_BPM_CONTROLLER,       value: "7u  << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_PID_CONTROLLER,       value: "8u  << TASK_OFFSET_SHIFT" }
+      - { name: TASK_OFFSET_LUMEX_LCD,            value: "9u  << TASK_OFFSET_SHIFT" }
+
+  - kind: struct
+    name: task_error_data
+    packed: true
+    fields:
+      - { type: uint32_t, name: timestamp }
+      - { type: uint32_t, name: error_code, comment: "task_offset | (warning ? WARNING_FLAG : 0) | error number" }
+
+  - { kind: static_assert, expr: "sizeof(task_error_data) == 4 + 4", message: "Size of task_error_data must be 8 bytes" }
+
+  - kind: code
+    text: |-
+      static inline task_error_data PopulateTaskErrorDataStruct(uint32_t timestamp, task_offset_t task_offset, uint32_t error_id)
+      {
+          task_error_data error_data;
+          error_data.timestamp = timestamp;
+          error_data.error_code = (uint32_t)task_offset | error_id;
+          return error_data;
+      }
+
+  - { kind: static_assert, expr: "sizeof(task_offset_t) == 4", message: "Size of task_offset_t must be 4 bytes" }
+
+  - kind: enum
+    name: session_controller_task_error_ids
+    base: uint32_t
+    values:
+      - { name: ERROR_SESSION_CONTROLLER_TIMESTAMP_TIMER_START_FAILURE, value: "0" }
+      - { name: ERROR_SESSION_CONTROLLER_INVALID_TASK_QUEUE_POINTER }
+      - { name: ERROR_SESSION_CONTROLLER_INVALID_UART1_MUTEX_POINTER }
+
+  - { kind: static_assert, expr: "sizeof(session_controller_task_error_ids) == 4", message: "Size of session_controller_task_error_ids must be 4 bytes" }
+
+  - kind: enum
+    name: bpm_task_error_ids
+    base: uint32_t
+    values:
+      - { name: ERROR_BPM_PWM_START_FAILURE, value: "0" }
+      - { name: ERROR_BPM_PWM_STOP_FAILURE }
+
+  - { kind: static_assert, expr: "sizeof(bpm_task_error_ids) == 4", message: "Size of bpm_task_error_ids must be 4 bytes" }
+
+  - kind: enum
+    name: lumex_lcd_task_error_ids
+    base: uint32_t
+    values:
+      - { name: ERROR_LUMEX_LCD_TIMER_START_FAILURE, value: "0" }
+
+  - { kind: static_assert, expr: "sizeof(lumex_lcd_task_error_ids) == 4", message: "Size of lumex_lcd_task_error_ids must be 4 bytes" }
+
+  - kind: enum
+    name: task_monitor_task_error_ids
+    base: uint32_t
+    values:
+      - { name: ERROR_TASK_MONITOR_INVALID_THREAD_ID_POINTER, value: "0" }
+
+  - { kind: static_assert, expr: "sizeof(task_monitor_task_error_ids) == 4", message: "Size of task_monitor_task_error_ids must be 4 bytes" }
+
+  - kind: enum
+    name: pid_controller_task_error_ids
+    base: uint32_t
+    values:
+      - { name: WARNING_PID_CONTROLLER_MESSAGE_QUEUE_FULL, value: "WARNING_FLAG" }
+
+  - { kind: static_assert, expr: "sizeof(pid_controller_task_error_ids) == 4", message: "Size of pid_controller_task_error_ids must be 4 bytes" }
+
+  - kind: enum
+    name: force_sensor_adc_task_error_ids
+    base: uint32_t
+    values:
+      - { name: ERROR_FORCE_SENSOR_ADC_START_FAILURE, value: "0" }
+
+  - { kind: static_assert, expr: "sizeof(force_sensor_adc_task_error_ids) == 4", message: "Size of force_sensor_adc_task_error_ids must be 4 bytes" }
+
+  - kind: enum
+    name: force_sensor_ads1115_error_ids
+    base: uint32_t
+    values:
+      - { name: ERROR_FORCE_SENSOR_ADS1115_INIT_FAILURE, value: "0" }
+      - { name: WARNING_FORCE_SENSOR_ADS1115_TRIGGER_CONVERSION_FAILURE, value: "WARNING_FLAG" }
+      - { name: WARNING_FORCE_SENSOR_ADS1115_GET_CONVERSION_FAILURE }
+
+  - { kind: static_assert, expr: "sizeof(force_sensor_ads1115_error_ids) == 4", message: "Size of force_sensor_ads1115_error_ids must be 4 bytes" }
+
+  - kind: comment
+    text: |-
+      ****************************************************
+      USB AND PUBLIC MESSAGES
+      ****************************************************
+
+  - kind: enum
+    name: usb_msg_type_t
+    base: uint32_t
+    values:
+      - { name: USB_MSG_INVALID, value: "0" }
+      - { name: USB_MSG_COMMAND,  blank_before: true, comment: "PC -> STM32 (do something)" }
+      - { name: USB_MSG_RESPONSE, comment: "STM32 -> PC (reply to command)" }
+      - { name: USB_MSG_EVENT,    comment: "STM32 -> PC (async event)" }
+      - { name: USB_MSG_STREAM,   comment: "STM32 -> PC (continuous data)" }
+      - { name: USB_MSG_CONFIG,   comment: "PC -> STM32 (set parameters)" }
+      - { name: USB_MSG_STATUS,   comment: "STM32 -> PC (health / state)" }
+      - { name: USB_MSG_ERROR,    blank_before: true, comment: "STM32 -> PC (error report)" }
+      - { name: USB_MSG_WARNING,  comment: "STM32 -> PC (warning report)" }
+
+  - { kind: static_assert, expr: "sizeof(usb_msg_type_t) == 4", message: "Size of usb_msg_type_t must be 4 bytes" }
+
+  - kind: struct
+    name: usb_msg_header_t
+    packed: true
+    fields:
+      - { type: usb_msg_type_t, name: msg_type,    comment: "protocol-level intent" }
+      - { type: task_offset_t,  name: task_offset, comment: "which module owns payload" }
+      - { type: uint32_t,       name: payload_len, comment: "bytes following header" }
+
+  - { kind: static_assert, expr: "sizeof(usb_msg_header_t) == 12", message: "Size of usb_msg_header_t must be 12 bytes" }
+
+  - kind: comment
+    text: |-
+      ---- Host -> device framed command envelope -------------------------------
+      Inbound (PC -> STM32) frames are wrapped so the parser can resync after a ring
+      overflow drops bytes mid-stream:
+        [uint16_t USB_FRAME_SOF][usb_msg_header_t header][payload bytes][uint16_t crc]
+      crc is CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF) computed over the header
+      bytes followed by the payload bytes (the SOF marker and crc field themselves are
+      excluded). Multi-byte fields are little-endian, matching both the STM32 and the
+      x86 host. The same envelope is reused for the host-side parser.
+
+  - { kind: define, name: USB_FRAME_SOF,      value: "0xA55Au" }
+  - { kind: define, name: USB_FRAME_CRC_INIT, value: "0xFFFFu" }
+  - { kind: define, name: USB_FRAME_CRC_POLY, value: "0x1021u" }
+
+  - kind: comment
+    text: |-
+      Largest inbound payload the firmware accepts; frames claiming more are treated as
+      a spurious SOF and skipped during resync.
+
+  - { kind: define, name: USB_RX_MAX_PAYLOAD, value: "128u" }
+
+  - kind: comment
+    text: |-
+      Shared CRC so firmware and host compute identical checksums over a frame body.
+
+  - kind: code
+    text: |-
+      static inline uint16_t usb_frame_crc16(const uint8_t *data, size_t len)
+      {
+          uint16_t crc = USB_FRAME_CRC_INIT;
+          for (size_t i = 0; i < len; ++i)
+          {
+              crc ^= (uint16_t)((uint16_t)data[i] << 8);
+              for (int bit = 0; bit < 8; ++bit)
+              {
+                  crc = (crc & 0x8000u) ? (uint16_t)((crc << 1) ^ USB_FRAME_CRC_POLY)
+                                        : (uint16_t)(crc << 1);
+              }
+          }
+          return crc;
+      }
+
+  - kind: comment
+    text: |-
+      ---- Host command / firmware response payloads ----------------------------
+      COMMAND and CONFIG frame payloads (PC -> STM32) begin with this header. The
+      opcode is namespaced by the frame's task_offset (commands addressed to
+      TASK_OFFSET_USB_CONTROLLER use usb_controller_command_t, and so on). msg_id is
+      chosen by the host and echoed in the matching RESPONSE so a reply can be
+      correlated to its request. msg_id 0 is reserved for firmware-internal commands
+      that want no host ack; hosts use ids >= 1.
+
+  - kind: struct
+    name: usb_cmd_header_t
+    packed: true
+    fields:
+      - { type: uint16_t, name: opcode }
+      - { type: uint16_t, name: msg_id }
+
+  - { kind: static_assert, expr: "sizeof(usb_cmd_header_t) == 4", message: "Size of usb_cmd_header_t must be 4 bytes" }
+
+  - kind: comment
+    text: |-
+      RESPONSE frame payload (STM32 -> PC): echoes the command's opcode + msg_id and
+      reports a status. Sent with task_offset set to the module that completed it, so
+      the host learns both which message (msg_id) and which module (frame task_offset)
+      acked. For a routed setting this is the full-path ack: it is emitted only after
+      the owning task has actually applied the command, with the real result status.
+    # NOTE: see [[usb-command-routing-direct-to-task]] -- USB routes settings straight
+    # to the owning task; the RESPONSE is the far end of that round trip.
+
+  - kind: struct
+    name: usb_response_data_t
+    packed: true
+    fields:
+      - { type: uint16_t, name: opcode }
+      - { type: uint16_t, name: msg_id }
+      - { type: uint32_t, name: status, comment: "usb_response_status_t" }
+
+  - { kind: static_assert, expr: "sizeof(usb_response_data_t) == 8", message: "Size of usb_response_data_t must be 8 bytes" }
+
+  - kind: enum
+    name: usb_response_status_t
+    base: uint32_t
+    values:
+      - { name: USB_RSP_OK, value: "0" }
+      - { name: USB_RSP_UNKNOWN_COMMAND, comment: "opcode not recognised by the target module" }
+      - { name: USB_RSP_MALFORMED,       comment: "payload too short / body out of range" }
+      - { name: USB_RSP_NOT_SUPPORTED,   comment: "task_offset has no command route" }
+      - { name: USB_RSP_DEVICE_ERROR,    comment: "target applied it but the device write failed (e.g. I2C)" }
+      - { name: USB_RSP_QUEUE_FULL,      comment: "target task's command queue was full" }
+
+  - kind: enum
+    name: usb_controller_command_t
+    base: uint16_t
+    comment: |-
+      USB-controller-local commands: frames addressed to TASK_OFFSET_USB_CONTROLLER.
+    values:
+      - { name: USB_CMD_HELLO, value: "0", comment: "host handshake; firmware replies USB_MSG_RESPONSE / USB_RSP_OK" }
+
+  - kind: enum
+    name: force_sensor_command_opcode
+    base: uint16_t
+    comment: |-
+      Force-sensor (ADS1115) commands: frames addressed to TASK_OFFSET_FORCE_SENSOR_ADS1115.
+    values:
+      - { name: FORCE_SENSOR_CMD_SET_DATA_RATE, value: "0", comment: "body[0] = ADS1115_RATE_* code (0..7)" }
+
+  - kind: struct
+    name: optical_encoder_output_data
+    fields:
+      - { type: uint32_t, name: timestamp,            comment: "Timestamp of the reading" }
+      - { type: float,    name: angular_velocity,     comment: "Measured angular velocity" }
+      - { type: uint32_t, name: raw_value,            comment: "In case users want to have custom implementation with it" }
+      - { type: float,    name: angular_acceleration, comment: "Measured angular acceleration" }
+
+  - { kind: static_assert, expr: "sizeof(optical_encoder_output_data) == 4 + 4 + 4 + 4", message: "Size of optical_encoder_output_data must be 16 bytes" }
+
+  - kind: struct
+    name: forcesensor_output_data
+    fields:
+      - { type: uint32_t, name: timestamp }
+      - { type: float,    name: force }
+      - { type: uint32_t, name: raw_value }
+
+  - { kind: static_assert, expr: "sizeof(forcesensor_output_data) == 4 + 4 + 4", message: "Size of forcesensor_output_data must be 12 bytes" }
+
+  - kind: struct
+    name: bpm_output_data
+    fields:
+      - { type: uint32_t, name: timestamp }
+      - { type: float,    name: duty_cycle }
+      - { type: uint32_t, name: raw_value, comment: "Really just padding to match the other output data types" }
+
+  - { kind: static_assert, expr: "sizeof(bpm_output_data) == 4 + 4 + 4", message: "Size of bpm_output_data must be 12 bytes" }
+
+  - kind: struct
+    name: task_monitor_output_data
+    fields:
+      - { type: uint32_t,      name: timestamp }
+      - { type: task_offset_t, name: task_offset }
+      - { type: int,           name: task_state }
+      - { type: uint32_t,      name: free_bytes }
+
+  - { kind: static_assert, expr: "sizeof(task_monitor_output_data) == 4 + 4 + 4 + 4", message: "Size of task_monitor_output_data must be 16 bytes" }
+
+  - kind: code
+    text: |-
+      #ifdef __cplusplus
+      }
+      #endif

--- a/tools/message_gen/templates/header.h.j2
+++ b/tools/message_gen/templates/header.h.j2
@@ -1,0 +1,59 @@
+{#- Generic header template, shared by every schema (messages_public, messages_private,
+    ...). Rendered by generate.py with trim_blocks + lstrip_blocks ON, so a line that
+    holds only a {% %} block tag emits nothing. Rule that keeps the output well-formed:
+    every line that produces text ends in a {{ expression }} or literal, never in a
+    {% block %} (otherwise trim_blocks would swallow that line's newline).
+
+    An include entry is either a string (-> <angle>) or a mapping {local: "x.h"} (-> "x.h").
+    A struct field may carry `array: N` to emit `type name[N];`. -#}
+// AUTO-GENERATED from tools/message_gen/schema/{{ schema_name }} by generate.py -- DO NOT EDIT.
+// Change that schema and re-run tools/message_gen/generate.py (CI verifies they match).
+#ifndef {{ guard }}
+#define {{ guard }}
+
+{% for inc in includes %}
+{% if inc is mapping %}
+#include "{{ inc.local }}"
+{% else %}
+#include <{{ inc }}>
+{% endif %}
+{% endfor %}
+{% for s in sections %}
+
+{% if s.kind == "comment" %}
+{% for line in s.text.rstrip("\n").split("\n") %}
+// {{ line }}
+{% endfor %}
+{% elif s.kind == "define" %}
+#define {{ s.name }} {{ s.value }}{{ ("              // " ~ s.comment) if s.comment else "" }}
+{% elif s.kind == "code" %}
+{{ s.text.rstrip("\n") }}
+{% elif s.kind == "enum" %}
+{% if s.comment %}
+{% for line in s.comment.rstrip("\n").split("\n") %}
+// {{ line }}
+{% endfor %}
+{% endif %}
+typedef enum : {{ s.base }}
+{
+{% for v in s["values"] %}
+{{ "\n" if v.blank_before else "" }}    {{ v.name }}{{ (" = " ~ v.value) if v.value is defined else "" }}{{ "," if not loop.last else "" }}{{ ("   // " ~ v.comment) if v.comment else "" }}
+{% endfor %}
+} {{ s.name }};
+{% elif s.kind == "struct" %}
+{% if s.comment %}
+{% for line in s.comment.rstrip("\n").split("\n") %}
+// {{ line }}
+{% endfor %}
+{% endif %}
+typedef struct{{ " __attribute__((packed))" if s.packed else "" }} {
+{% for f in s.fields %}
+    {{ f.type }} {{ f.name }}{{ ("[" ~ f.array ~ "]") if f.array else "" }};{{ ("   // " ~ f.comment) if f.comment else "" }}
+{% endfor %}
+} {{ s.name }};
+{% elif s.kind == "static_assert" %}
+_Static_assert({{ s.expr }}, "{{ s.message }}");
+{% endif %}
+{% endfor %}
+
+#endif /* {{ guard }} */

--- a/tools/message_gen/verify.py
+++ b/tools/message_gen/verify.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Prove the generated header matches a reference, ignoring comments + whitespace.
+
+Used two ways:
+  * one-off faithfulness check against the hand-written header
+  * CI drift guard: regenerate to a temp file, then `verify.py committed.h temp.h`
+    fails the build if someone hand-edited the generated header instead of the schema.
+
+It compares the two files as C token streams: comments are stripped, all whitespace
+(including brace placement) is irrelevant, and a trailing comma before `}` is treated
+as optional (it is insignificant in C). An empty diff therefore means the two files
+declare the same C -- same types, fields, enum values, sizes and static_asserts --
+regardless of formatting, which the hand-written header is not internally consistent
+about anyway.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+import sys
+from pathlib import Path
+
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+# A C token: string literal, identifier/number, or a single punctuation char.
+_TOKEN = re.compile(r'"[^"]*"|[A-Za-z_]\w*|\d+|\S')
+
+
+def normalize(src: str) -> list[str]:
+    src = _BLOCK_COMMENT.sub("", src)
+    src = "\n".join(line.split("//", 1)[0] for line in src.splitlines())
+    toks = _TOKEN.findall(src)
+    out: list[str] = []
+    for i, tok in enumerate(toks):
+        if tok == "," and i + 1 < len(toks) and toks[i + 1] == "}":
+            continue  # drop trailing comma before a closing brace
+        out.append(tok)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: verify.py <reference.h> <generated.h>", file=sys.stderr)
+        return 2
+    ref, gen = (normalize(Path(p).read_text()) for p in argv)
+    diff = list(difflib.unified_diff(ref, gen, argv[0], argv[1], lineterm=""))
+    if diff:
+        print("\n".join(diff))
+        print(f"\nFAIL: {len(diff)} normalized diff lines", file=sys.stderr)
+        return 1
+    print(f"OK: semantically identical ({len(ref)} normalized lines)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Add tools/message_gen: per-header YAML schemas plus a Jinja2 generator that emits messages_public.h and messages_private.h from one source of truth, a token-level drift check (verify.py / check.py), and a CI job that fails if a committed header is out of sync with its schema.

Regenerate both headers from the schema. messages_public.h now emits a single _Static_assert per type instead of the dual #ifdef STM32H7xx_H / static_assert block; messages_private.h is semantically unchanged (reformatted to the generator's style). Both compile under gcc -std=c23 with all size asserts passing. Headers carry a DO-NOT-EDIT banner pointing back at the schema.