### PR TITLE
Add device-announced, version-checked USB handshake

### DIFF
--- a/Core/Inc/MessagePassing/messages_public.h
+++ b/Core/Inc/MessagePassing/messages_public.h
@@ -167,6 +167,14 @@ _Static_assert(sizeof(usb_msg_header_t) == 12, "Size of usb_msg_header_t must be
 
 #define USB_RX_MAX_PAYLOAD 128u
 
+// Wire-format version the device announces (usb_device_ready_event) and the host
+// echoes back in its USB_CMD_ACK. Bump whenever any struct/enum below changes layout
+// so a host built against an older schema is rejected at the handshake instead of
+// silently mis-decoding the stream. Build-time static_asserts guard struct sizes;
+// this guards the live link at runtime.
+
+#define USB_PROTOCOL_VERSION 1u
+
 // Shared CRC so firmware and host compute identical checksums over a frame body.
 
 static inline uint16_t usb_frame_crc16(const uint8_t *data, size_t len)
@@ -220,14 +228,26 @@ typedef enum : uint32_t
     USB_RSP_MALFORMED,   // payload too short / body out of range
     USB_RSP_NOT_SUPPORTED,   // task_offset has no command route
     USB_RSP_DEVICE_ERROR,   // target applied it but the device write failed (e.g. I2C)
-    USB_RSP_QUEUE_FULL   // target task's command queue was full
+    USB_RSP_QUEUE_FULL,   // target task's command queue was full
+    USB_RSP_VERSION_MISMATCH   // ACK protocol_version != USB_PROTOCOL_VERSION; link refused
 } usb_response_status_t;
 
 // USB-controller-local commands: frames addressed to TASK_OFFSET_USB_CONTROLLER.
 typedef enum : uint16_t
 {
-    USB_CMD_HELLO = 0   // host handshake; firmware replies USB_MSG_RESPONSE / USB_RSP_OK
+    USB_CMD_ACK = 0   // host acks the device-ready announce; body = uint32 protocol_version. Firmware replies USB_RSP_OK or USB_RSP_VERSION_MISMATCH
 } usb_controller_command_t;
+
+// Device-ready announcement (STM32 -> PC): emitted as USB_MSG_EVENT with task_offset
+// TASK_OFFSET_USB_CONTROLLER and repeated (~every 200ms) until the host answers with
+// USB_CMD_ACK. Carries the firmware's USB_PROTOCOL_VERSION so the host can confirm the
+// wire format matches before it trusts -- or acks -- the stream.
+
+typedef struct {
+    uint32_t protocol_version;   // == USB_PROTOCOL_VERSION
+} usb_device_ready_event;
+
+_Static_assert(sizeof(usb_device_ready_event) == 4, "Size of usb_device_ready_event must be 4 bytes");
 
 // Force-sensor (ADS1115) commands: frames addressed to TASK_OFFSET_FORCE_SENSOR_ADS1115.
 typedef enum : uint16_t

--- a/Core/Inc/Tasks/USB/USBController.hpp
+++ b/Core/Inc/Tasks/USB/USBController.hpp
@@ -61,7 +61,15 @@ class USBController
         // Frame a USB_MSG_RESPONSE into the TX buffer (echoes opcode/msg_id + status).
         void SendResponse(task_offset_t taskOffset, uint16_t opcode, uint16_t msg_id, uint32_t status);
 
-        // Block until the host completes the USB_CMD_HELLO handshake (mock/debug path).
+        // Frame a USB_MSG_EVENT carrying usb_device_ready_event{USB_PROTOCOL_VERSION}. The
+        // host watches for this and replies USB_CMD_ACK to start the link.
+        void SendDeviceReady();
+
+        // While the host has not yet handshaked, re-announce device-ready at most every
+        // DEVICE_READY_ANNOUNCE_MS so a host that connects late still sees one. No-op once ready.
+        void AnnounceReadyIfDue();
+
+        // Block until the host completes the USB_CMD_ACK handshake (mock/debug path).
         void WaitForHandshake();
 
         template <typename T>
@@ -125,7 +133,8 @@ class USBController
         uint8_t _txBuffer[USB_TX_BUFFER_SIZE];
         int _txBufferIndex = 0;
 
-        bool _appReady;   // set once the host completes the USB_CMD_HELLO handshake
+        bool _appReady;            // set once the host completes the USB_CMD_ACK handshake
+        uint32_t _lastAnnounceTick; // tick of the last device-ready announce (AnnounceReadyIfDue)
 };
 
 #endif // INC_TASKS_USB_USBCONTROLLER_HPP_

--- a/Core/Src/Tasks/USB/README.md
+++ b/Core/Src/Tasks/USB/README.md
@@ -17,15 +17,32 @@ related: [MessagePassing, TaskMonitor, SessionController]
 Drains the data/error streams, prefixes each with a `usb_msg_header_t`, and transmits
 over USB CDC. Each record = header + payload (see the wire protocol in [[MessagePassing]]).
 
+A full sequence of every message — handshake, streaming, and command routing (including the
+routed "non-posted" ack) — is in [`usb_message_flow.puml`](usb_message_flow.puml).
+
 ## Flow (`Run()`)
-1. `ReceiveAppAck()` — wait for the PC to send `"OK"` before streaming.
-2. Wait for SessionController to enable USB logging.
-3. While enabled, frame and append:
+Each iteration:
+1. `ProcessIncomingFrames()` — pull + route CRC-validated host frames (always, so the host can
+   handshake/configure regardless of logging state).
+2. `ProcessCompletions()` — relay applied-command acks as `USB_MSG_RESPONSE`.
+3. Pick up the SessionController's USB logging enable/disable.
+4. **Handshake gate:** while `!_appReady`, `AnnounceReadyIfDue()` emits a `usb_device_ready_event`
+   (`USB_MSG_EVENT`, `TASK_OFFSET_USB_CONTROLLER`) about every `DEVICE_READY_ANNOUNCE_MS`.
+5. Once `_appReady && enableUSB`, frame and append the streams:
    - `optical_encoder_output_data` (`USB_MSG_STREAM`, `TASK_OFFSET_OPTICAL_ENCODER`)
    - `forcesensor_output_data` (`USB_MSG_STREAM`, active force-sensor offset)
    - `bpm_output_data`, `task_monitor_output_data`
    - errors via `ProcessErrorsAndWarnings()`.
-4. `CDC_Transmit_FS(_txBuffer, …)`; delay `USB_TASK_OSDELAY`.
+6. `CDC_Transmit_FS(_txBuffer, …)`; delay `USB_TASK_OSDELAY`.
+
+## Handshake (device-announced)
+The firmware streams nothing until the host acknowledges it. While `_appReady` is false the
+device repeatedly announces `usb_device_ready_event{ USB_PROTOCOL_VERSION }`; the host answers
+with a framed `USB_CMD_ACK` whose body is its own `USB_PROTOCOL_VERSION`. `HandleUsbLocalCommand`
+sets `_appReady` and replies `USB_RSP_OK` when the versions match, or `USB_RSP_VERSION_MISMATCH`
+(and keeps announcing) when they differ — so a host built against a stale schema is rejected at
+the link instead of silently mis-decoding the stream. `MockMessages()` gates on the same
+handshake via `WaitForHandshake()`.
 
 ## Error/warning framing
 `ProcessErrorsAndWarnings()` reads `task_error_data` from `task_error_circular_buffer` and sets

--- a/Core/Src/Tasks/USB/USBController.cpp
+++ b/Core/Src/Tasks/USB/USBController.cpp
@@ -9,6 +9,9 @@
 #define ACTIVE_FORCE_SENSOR_TASK_OFFSET TASK_OFFSET_FORCE_SENSOR_ADC
 #endif
 
+// Cadence of the device-ready announcement while waiting for the host's USB_CMD_ACK.
+static constexpr uint32_t DEVICE_READY_ANNOUNCE_MS = 200;
+
 extern size_t optical_encoder_circular_buffer_index_writer;
 extern size_t forcesensor_circular_buffer_index_writer;
 extern size_t bpm_circular_buffer_index_writer;
@@ -34,7 +37,8 @@ USBController::USBController(osMessageQueueId_t sessionControllerToUsbController
       _taskCompletionQueue(taskCompletionQueue),
       _txBuffer{},
       _txBufferIndex(0),
-      _appReady(false)
+      _appReady(false),
+      _lastAnnounceTick(0)
 {}
 
 bool USBController::Init()
@@ -124,16 +128,28 @@ void USBController::DispatchFrame(const usb_msg_header_t& header, const uint8_t*
 
 void USBController::HandleUsbLocalCommand(const usb_cmd_header_t& cmd, const uint8_t* body, size_t bodyLen)
 {
-    (void)body;
-    (void)bodyLen;
-
     switch (cmd.opcode)
     {
-        case USB_CMD_HELLO:
-            // Host is present and listening: unblock streaming and acknowledge.
+        case USB_CMD_ACK:
+        {
+            // Host acknowledges the device-ready announce. Its body carries the host's
+            // protocol version; refuse the link (and keep announcing) if it disagrees with
+            // ours, so a host built against an older schema never mis-decodes the stream.
+            uint32_t hostVersion = 0;
+            if (bodyLen >= sizeof(uint32_t))
+            {
+                memcpy(&hostVersion, body, sizeof(uint32_t));
+            }
+            if (hostVersion != USB_PROTOCOL_VERSION)
+            {
+                SendResponse(TASK_OFFSET_USB_CONTROLLER, cmd.opcode, cmd.msg_id, USB_RSP_VERSION_MISMATCH);
+                break;
+            }
+            // Versions match: unblock streaming and acknowledge.
             _appReady = true;
             SendResponse(TASK_OFFSET_USB_CONTROLLER, cmd.opcode, cmd.msg_id, USB_RSP_OK);
             break;
+        }
 
         default:
             SendResponse(TASK_OFFSET_USB_CONTROLLER, cmd.opcode, cmd.msg_id, USB_RSP_UNKNOWN_COMMAND);
@@ -170,13 +186,43 @@ void USBController::SendResponse(task_offset_t taskOffset, uint16_t opcode, uint
     AddToBuffer<usb_response_data_t>(&resp, sizeof(resp));
 }
 
+void USBController::SendDeviceReady()
+{
+    usb_device_ready_event evt = { USB_PROTOCOL_VERSION };
+
+    StallIfIsBufferFull(IsBufferFull(sizeof(evt)));
+
+    usb_msg_header_t header =
+    {
+        .msg_type = USB_MSG_EVENT,
+        .task_offset = TASK_OFFSET_USB_CONTROLLER,
+        .payload_len = sizeof(evt)
+    };
+    AddToBuffer<usb_msg_header_t>(&header, sizeof(header));
+    AddToBuffer<usb_device_ready_event>(&evt, sizeof(evt));
+}
+
+void USBController::AnnounceReadyIfDue()
+{
+    uint32_t now = osKernelGetTickCount();
+    // First call (_lastAnnounceTick == 0) announces immediately so a host already
+    // listening when the task starts is not made to wait a full interval.
+    if (_lastAnnounceTick != 0 && (now - _lastAnnounceTick) < DEVICE_READY_ANNOUNCE_MS)
+    {
+        return;
+    }
+    _lastAnnounceTick = now;
+    SendDeviceReady();
+}
+
 void USBController::WaitForHandshake()
 {
-    // Block until the host completes the USB_CMD_HELLO handshake, flushing the
-    // response as soon as it is queued. Used by the mock/debug path.
+    // Block until the host completes the USB_CMD_ACK handshake, announcing device-ready
+    // and flushing the TX buffer as it goes. Used by the mock/debug path.
     while (!_appReady)
     {
         ProcessIncomingFrames();
+        AnnounceReadyIfDue();
 
         if (_txBufferIndex > 0 && CDC_Transmit_FS(_txBuffer, _txBufferIndex) != USBD_BUSY)
         {
@@ -271,7 +317,14 @@ void USBController::Run()
         // 3. Pick up the latest logging enable/disable from the SessionController.
         GetLatestFromQueue(_sessionControllerToUsbController, &enableUSB, sizeof(enableUSB), 0);
 
-        // 4. Stream sensor/error data only once the host has handshaked (USB_CMD_HELLO)
+        // 3b. Until the host handshakes, periodically announce that the device is ready so
+        //     the host knows to reply USB_CMD_ACK. Self-throttled; stops once _appReady.
+        if (!_appReady)
+        {
+            AnnounceReadyIfDue();
+        }
+
+        // 4. Stream sensor/error data only once the host has handshaked (USB_CMD_ACK)
         //    and logging is enabled.
         if (_appReady && enableUSB)
         {

--- a/Core/Src/Tasks/USB/usb_message_flow.puml
+++ b/Core/Src/Tasks/USB/usb_message_flow.puml
@@ -1,0 +1,93 @@
+@startuml USB Message Flow
+
+title USB Controller — Host Link, Streaming & Command Routing
+
+skinparam defaultFontSize 12
+skinparam shadowing false
+skinparam sequenceMessageAlign center
+skinparam ParticipantPadding 16
+skinparam BoxPadding 12
+skinparam sequence {
+    LifeLineBorderColor #2C7BB6
+    ArrowColor #1A5276
+    ArrowFontColor #1A5276
+    ArrowFontSize 11
+}
+
+actor "PC App\n(Dyno.App / Dyno.Core)" as App
+box "STM32 firmware" #F4F9FF
+participant "USB Controller\n(usbcontroller_main)" as USB
+participant "Owning Task\n(e.g. ForceSensor)" as Task
+participant "SessionController" as Session
+end box
+
+== Handshake — device-announced, version-checked ==
+
+note over USB
+  _appReady = false
+  → the device streams nothing yet
+end note
+
+loop every ~DEVICE_READY_ANNOUNCE_MS, until _appReady
+    USB -> App : **USB_MSG_EVENT** / TASK_OFFSET_USB_CONTROLLER\nusb_device_ready_event{ USB_PROTOCOL_VERSION }
+end
+
+App -> USB : **USB_MSG_COMMAND** / TASK_OFFSET_USB_CONTROLLER\nUSB_CMD_ACK, body = host USB_PROTOCOL_VERSION
+note over USB : HandleUsbLocalCommand()\ncompare host vs firmware version
+
+alt versions match
+    USB -> App : **USB_MSG_RESPONSE**  USB_RSP_OK\n(sets _appReady = true)
+else mismatch
+    USB -> App : **USB_MSG_RESPONSE**  USB_RSP_VERSION_MISMATCH\n(stays not-ready, keeps announcing)
+end
+
+== Streaming — only while _appReady && SessionController enabled ==
+
+Session -> USB : enable USB logging
+note over USB, Task : sensor tasks fill circular buffers / the task-monitor queue
+
+loop each Run() iteration (drain & frame)
+    USB -> App : USB_MSG_STREAM  optical_encoder_output_data   (TASK_OFFSET_OPTICAL_ENCODER)
+    USB -> App : USB_MSG_STREAM  forcesensor_output_data       (active force-sensor offset)
+    USB -> App : USB_MSG_STREAM  bpm_output_data               (TASK_OFFSET_BPM_CONTROLLER)
+    USB -> App : USB_MSG_STREAM  task_monitor_output_data      (TASK_OFFSET_TASK_MONITOR)
+    USB -> App : USB_MSG_ERROR / USB_MSG_WARNING  task_error_data\n(task_offset + number packed in error_code)
+end
+
+== Host command — USB-controller-local (handled in place) ==
+
+App -> USB : USB_MSG_COMMAND / TASK_OFFSET_USB_CONTROLLER\nopcode, msg_id (>= 1)
+note over USB : HandleUsbLocalCommand() answers directly
+USB -> App : USB_MSG_RESPONSE  echo opcode + msg_id, status
+
+== Host command — routed to a task (full-path "non-posted" ack) ==
+
+App -> USB : USB_MSG_COMMAND / e.g. TASK_OFFSET_FORCE_SENSOR_ADS1115\nopcode (FORCE_SENSOR_CMD_SET_DATA_RATE), msg_id (>= 1), body
+note over USB
+  DispatchFrame() → QueueForTaskOffset()
+  Ack is **non-posted**: the USB task sends
+  no RESPONSE here — the owning task will.
+end note
+
+alt route exists & body fits & queue not full
+    USB -> Task : usb_task_command{ opcode, msg_id, body }\n(owning task's command queue)
+    note over Task : ProcessCommands() → ApplyCommand()\n(real device write, e.g. ADS1115 setRate)
+    Task -> USB : usb_task_completion{ task_offset, opcode, msg_id, status }\n(shared completion queue)
+    note over USB : ProcessCompletions()\n(msg_id 0 = internal command → dropped, no ack)
+    USB -> App : USB_MSG_RESPONSE  echo opcode + msg_id, **real applied status**
+else no route / body too big / queue full
+    USB -> App : USB_MSG_RESPONSE\nUSB_RSP_NOT_SUPPORTED | USB_RSP_MALFORMED | USB_RSP_QUEUE_FULL
+end
+
+note over App, Task
+  **Framing.** Inbound (PC → STM32) frames are wrapped so the parser can resync:
+  [uint16 SOF][usb_msg_header_t][payload][uint16 CRC-16/CCITT-FALSE].
+  Outbound (STM32 → PC) records are unframed: usb_msg_header_t + payload (USB-CDC is reliable).
+
+  **Correlation.** msg_id ties each RESPONSE to its COMMAND; msg_id 0 is firmware-internal (no host ack).
+
+  **Contract.** All struct/enum layouts are generated from messages_public.yaml (single source of
+  truth); USB_PROTOCOL_VERSION guards that the host and firmware agree at runtime.
+end note
+
+@enduml

--- a/tools/message_gen/schema/messages_public.yaml
+++ b/tools/message_gen/schema/messages_public.yaml
@@ -206,6 +206,16 @@ sections:
 
   - kind: comment
     text: |-
+      Wire-format version the device announces (usb_device_ready_event) and the host
+      echoes back in its USB_CMD_ACK. Bump whenever any struct/enum below changes layout
+      so a host built against an older schema is rejected at the handshake instead of
+      silently mis-decoding the stream. Build-time static_asserts guard struct sizes;
+      this guards the live link at runtime.
+
+  - { kind: define, name: USB_PROTOCOL_VERSION, value: "1u" }
+
+  - kind: comment
+    text: |-
       Shared CRC so firmware and host compute identical checksums over a frame body.
 
   - kind: code
@@ -274,6 +284,7 @@ sections:
       - { name: USB_RSP_NOT_SUPPORTED,   comment: "task_offset has no command route" }
       - { name: USB_RSP_DEVICE_ERROR,    comment: "target applied it but the device write failed (e.g. I2C)" }
       - { name: USB_RSP_QUEUE_FULL,      comment: "target task's command queue was full" }
+      - { name: USB_RSP_VERSION_MISMATCH, comment: "ACK protocol_version != USB_PROTOCOL_VERSION; link refused" }
 
   - kind: enum
     name: usb_controller_command_t
@@ -281,7 +292,21 @@ sections:
     comment: |-
       USB-controller-local commands: frames addressed to TASK_OFFSET_USB_CONTROLLER.
     values:
-      - { name: USB_CMD_HELLO, value: "0", comment: "host handshake; firmware replies USB_MSG_RESPONSE / USB_RSP_OK" }
+      - { name: USB_CMD_ACK, value: "0", comment: "host acks the device-ready announce; body = uint32 protocol_version. Firmware replies USB_RSP_OK or USB_RSP_VERSION_MISMATCH" }
+
+  - kind: comment
+    text: |-
+      Device-ready announcement (STM32 -> PC): emitted as USB_MSG_EVENT with task_offset
+      TASK_OFFSET_USB_CONTROLLER and repeated (~every 200ms) until the host answers with
+      USB_CMD_ACK. Carries the firmware's USB_PROTOCOL_VERSION so the host can confirm the
+      wire format matches before it trusts -- or acks -- the stream.
+
+  - kind: struct
+    name: usb_device_ready_event
+    fields:
+      - { type: uint32_t, name: protocol_version, comment: "== USB_PROTOCOL_VERSION" }
+
+  - { kind: static_assert, expr: "sizeof(usb_device_ready_event) == 4", message: "Size of usb_device_ready_event must be 4 bytes" }
 
   - kind: enum
     name: force_sensor_command_opcode


### PR DESCRIPTION
Replace the host-sent USB_CMD_HELLO with a device-announced handshake: while not yet acknowledged the USB controller periodically emits a usb_device_ready_event (USB_MSG_EVENT) carrying USB_PROTOCOL_VERSION, and the host replies with USB_CMD_ACK echoing its own version. The controller sets _appReady and answers USB_RSP_OK on a match, or USB_RSP_VERSION_MISMATCH (and keeps announcing) on a mismatch, so a host built against a stale schema is refused at the link instead of mis-decoding the stream.

Schema (single source of truth) gains USB_PROTOCOL_VERSION, usb_device_ready_event, USB_RSP_VERSION_MISMATCH and the HELLO->ACK rename; messages_public.h regenerated. Also add usb_message_flow.puml documenting the handshake, streaming and routed ("non-posted") command/completion flow, and refresh the USB README's stale ReceiveAppAck/"OK" description.